### PR TITLE
Removed reference to free_locations

### DIFF
--- a/crates/cargo-webassembly/src/template/js-wasm.js
+++ b/crates/cargo-webassembly/src/template/js-wasm.js
@@ -227,7 +227,6 @@ window.JsWasm = {
       },
       releaseObject: function(handle) {
         this.objects[handle] = null;
-        this.free_locations.push(handle);
       }
     };
     return {

--- a/js-wasm.js
+++ b/js-wasm.js
@@ -227,7 +227,6 @@ window.JsWasm = {
       },
       releaseObject: function(handle) {
         this.objects[handle] = null;
-        this.free_locations.push(handle);
       }
     };
     return {


### PR DESCRIPTION
I had some trouble running the examples/snake demo. The issue seems to be in the js-wasm.js file which is trying to push a value onto the undeclared variable 'free_locations'. Removing that line fixed the issue.