### PR TITLE
Explicitly specify character encoding in html files

### DIFF
--- a/crates/cargo-webassembly/src/template/index.html
+++ b/crates/cargo-webassembly/src/template/index.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="utf-8">
         <title>PROJECT</title>
         <link rel="shortcut icon" href="#" />
         <script src="/js-wasm.js"></script>

--- a/crates/webcomponent/examples/todo/index.html
+++ b/crates/webcomponent/examples/todo/index.html
@@ -1,5 +1,6 @@
 <html>
 <head>
+<meta charset="utf-8">
 <title>Todo</title>
 <!-- a polyfill for web components on some browsers -->
 <script src="https://unpkg.com/@webcomponents/webcomponentsjs@latest/webcomponents-loader.js"></script>

--- a/electron/index.html
+++ b/electron/index.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="utf-8">
         <title>My App!</title>
         <link rel="shortcut icon" href="#" />
         <script src="js-wasm.js"></script>

--- a/examples/assemblyscript_helloworld/index.html
+++ b/examples/assemblyscript_helloworld/index.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="utf-8">
         <link rel="shortcut icon" href="#" />
         <script src="../../js-wasm.js"></script>
         <script type="application/wasm" src="build/optimized.wasm"></script>

--- a/examples/canvas/index.html
+++ b/examples/canvas/index.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="utf-8">
         <link rel="shortcut icon" href="#" />
         <script src="../../js-wasm.js"></script>
         <script type="application/wasm" src="example.wasm"></script>

--- a/examples/helloworld/index.html
+++ b/examples/helloworld/index.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="utf-8">
         <link rel="shortcut icon" href="#" />
         <script src="../../js-wasm.js"></script>
         <script type="application/wasm" src="example.wasm"></script>

--- a/examples/snake/index.html
+++ b/examples/snake/index.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="utf-8">
         <link rel="shortcut icon" href="#" />
         <script src="../../js-wasm.js"></script>
         <script type="application/wasm" src="example.wasm"></script>

--- a/examples/timer/index.html
+++ b/examples/timer/index.html
@@ -1,5 +1,6 @@
 <html>
     <head>
+        <meta charset="utf-8">
         <link rel="shortcut icon" href="#" />
         <script src="../../js-wasm.js"></script>
         <script type="application/wasm" src="example.wasm"></script>


### PR DESCRIPTION
Running the examples in Firefox produces the following console error: 

> The character encoding of the HTML document was not declared. The document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must be declared in the document or in the transfer protocol.

The fix is to either send the encoding information from the server or to include it in the html files. I think adding it to the html files is simpler.